### PR TITLE
Introduce VSReuseInstance parameter for test settings

### DIFF
--- a/DeveloperGuide.md
+++ b/DeveloperGuide.md
@@ -86,6 +86,7 @@ follows:
 | VSHive        | The hive name, like "Exp" or "Default" |
 | VSLaunchTimeoutInSeconds [opt] | The number of seconds to wait for launch |
 | VSDebugMixedMode | True to use mixed-mode debugging for tests |
+| VSReuseInstance [opt] | False to disable the reuse of the same VS instance for distinct tests |
 | ScreenCapture [opt] | Relative path to capture screenshots to |
 | ScreenCaptureInterval [opt] | Milliseconds between screenshots |
 

--- a/VSTestHost/TesterTestAdapter.cs
+++ b/VSTestHost/TesterTestAdapter.cs
@@ -40,6 +40,7 @@ namespace Microsoft.VisualStudioTools.VSTestHost {
         private IRunContext _runContext;
         private TesteeTestAdapter _remote;
         private bool _mockVs;
+        private bool _reuseInstance;
 
         public TesterTestAdapter() { }
 
@@ -54,7 +55,8 @@ namespace Microsoft.VisualStudioTools.VSTestHost {
         ) {
             var hiveOption = string.IsNullOrEmpty(hive) ? "" : (" /rootSuffix " + hive);
 
-            if (_ide != null &&
+            if (_reuseInstance &&
+                _ide != null &&
                 _remote != null &&
                 application == _currentApplication &&
                 executable == _currentExecutable &&
@@ -169,6 +171,7 @@ namespace Microsoft.VisualStudioTools.VSTestHost {
             Version version;
             string launchTimeoutInSecondsString;
             int launchTimeoutInSeconds;
+            string reuseInstanceString;
 
             // VSApplication is the registry key name like 'VisualStudio'
             application = vars[VSTestProperties.VSApplication.Key] ?? VSTestProperties.VSApplication.VisualStudio;
@@ -216,6 +219,12 @@ namespace Microsoft.VisualStudioTools.VSTestHost {
                 return;
             }
 
+            if (!vars.TryGetValue(VSTestProperties.VSReuseInstance.Key, out reuseInstanceString) ||
+                !bool.TryParse(reuseInstanceString, out _reuseInstance))
+            {
+                // the default behavior is to reuse the current instance when possible
+                _reuseInstance = true;
+            }
 
             // TODO: Detect and perform first run of VS if necessary.
             // The first time a VS hive is run, the user sees a dialog allowing

--- a/VSTestHost/VSTestProperties.cs
+++ b/VSTestHost/VSTestProperties.cs
@@ -50,5 +50,9 @@ namespace Microsoft.VisualStudioTools.VSTestHost {
         public static class VSDebugMixedMode {
             public const string Key = "VSDebugMixedMode";
         }
+
+        public static class VSReuseInstance {
+            public const string Key = "VSReuseInstance";
+        }
     }
 }


### PR DESCRIPTION
This PR introduces a new VSReuseIntance parameter in the test settings file to control the reuse of the current VS instance for distinct tests. The default value is "true" to match the legacy behavior. The goal is to provide a way for the user to better control the test infrastructure. Visual Studio Tools for Unity is using such a setting. cc @zooba 