### PR TITLE
Patch Test platform config files

### DIFF
--- a/VSTestHost/InstallInVS2017.ps1
+++ b/VSTestHost/InstallInVS2017.ps1
@@ -28,10 +28,13 @@ copy "$source\Microsoft.VisualStudioTools.VSTestHost.15.0.pkgdef" "$vs\Common7\I
 gci @(
     "$vs\Common7\IDE\MSTest.exe.config",
     "$vs\Common7\IDE\QTAgent*.exe.config",
-    "$vs\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.*.exe.config"
+    "$vs\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.*.exe.config",
+    "$vs\Common7\IDE\Extensions\TestPlatform\QTAgent*.exe.config",
+    "$vs\Common7\IDE\Extensions\TestPlatform\vstest.*.exe.config"
 ) | ?{ Test-Path $_ } | %{
     $conf = [xml](gc $_);
-    if (-not $conf.configuration.runtime.assemblyBinding.probing.privatePath.Contains("CommonExtensions\Microsoft\Editor")) {
+	$privatePath = $conf.configuration.runtime.assemblyBinding.probing.privatePath;
+    if ($privatePath -and -not $privatePath.Contains("CommonExtensions\Microsoft\Editor")) {
         $conf.configuration.runtime.assemblyBinding.probing.privatePath += ";CommonExtensions\Platform;CommonExtensions\Microsoft\Editor";
 
         $n = $conf.configuration.runtime.assemblyBinding.AppendChild($conf.ImportNode(([xml]'<dependentAssembly>

--- a/VSTestHost/InstallInVS2017.ps1
+++ b/VSTestHost/InstallInVS2017.ps1
@@ -33,7 +33,7 @@ gci @(
     "$vs\Common7\IDE\Extensions\TestPlatform\vstest.*.exe.config"
 ) | ?{ Test-Path $_ } | %{
     $conf = [xml](gc $_);
-	$privatePath = $conf.configuration.runtime.assemblyBinding.probing.privatePath;
+    $privatePath = $conf.configuration.runtime.assemblyBinding.probing.privatePath;
     if ($privatePath -and -not $privatePath.Contains("CommonExtensions\Microsoft\Editor")) {
         $conf.configuration.runtime.assemblyBinding.probing.privatePath += ";CommonExtensions\Platform;CommonExtensions\Microsoft\Editor";
 


### PR DESCRIPTION
It seems that when using vstest.console or the IDE with 15.5.x, the QTAgent which is getting used to run test is getting picked from Common7\IDE\Extensions\TestPlatform. So patch config files for assembly probing.